### PR TITLE
Async functions to await a full or empty queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+* Added `Queue::wait_full` and `Queue::wait_empty` async methods
+
 ## [0.2.4] - 2022-11-4
 
 ### Fixed
@@ -42,8 +48,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - First release
 
-[unreleased]: https://github.com/bikeshedder/deadqueue/compare/0.2.1...HEAD
+[unreleased]: https://github.com/bikeshedder/deadqueue/compare/v0.2.4...HEAD
 [0.1.0]: https://github.com/bikeshedder/deadqueue/releases/tag/v0.1.0
 [0.2.0]: https://github.com/bikeshedder/deadqueue/releases/tag/v0.2.0
 [0.2.1]: https://github.com/bikeshedder/deadqueue/releases/tag/v0.2.1
 [0.2.2]: https://github.com/bikeshedder/deadqueue/releases/tag/v0.2.2
+[0.2.3]: https://github.com/bikeshedder/deadqueue/releases/tag/v0.2.3
+[0.2.4]: https://github.com/bikeshedder/deadqueue/releases/tag/v0.2.4

--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -7,12 +7,12 @@ impl Available {
     pub fn new(value: isize) -> Self {
         Self(AtomicIsize::new(value))
     }
-    pub fn sub(&self) -> TransactionSub {
-        self.0.fetch_sub(1, Ordering::Relaxed);
-        TransactionSub(&self.0)
+    pub fn sub(&self) -> (TransactionSub, isize) {
+        let previous = self.0.fetch_sub(1, Ordering::Relaxed);
+        (TransactionSub(&self.0), previous)
     }
-    pub fn add(&self) {
-        self.0.fetch_add(1, Ordering::Relaxed);
+    pub fn add(&self) -> isize {
+        self.0.fetch_add(1, Ordering::Relaxed)
     }
     pub fn get(&self) -> isize {
         self.0.load(Ordering::Relaxed)

--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -8,11 +8,11 @@ impl Available {
         Self(AtomicIsize::new(value))
     }
     pub fn sub(&self) -> (TransactionSub, isize) {
-        let previous = self.0.fetch_sub(1, Ordering::Relaxed);
-        (TransactionSub(&self.0), previous)
+        let new_len = self.0.fetch_sub(1, Ordering::Relaxed) - 1;
+        (TransactionSub(&self.0), new_len)
     }
     pub fn add(&self) -> isize {
-        self.0.fetch_add(1, Ordering::Relaxed)
+        self.0.fetch_add(1, Ordering::Relaxed) + 1
     }
     pub fn get(&self) -> isize {
         self.0.load(Ordering::Relaxed)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,8 @@
 //! at your option.
 #![warn(missing_docs)]
 
+use tokio::sync::watch;
+
 mod atomic;
 
 #[cfg(feature = "unlimited")]
@@ -109,3 +111,12 @@ pub mod resizable;
 
 #[cfg(feature = "limited")]
 pub mod limited;
+
+/// Private type alias for notify_full and notify_empty
+type Notifier = watch::Sender<()>;
+
+/// Initialize the notify_full sender
+fn new_notifier() -> Notifier {
+    let (sender, _) = watch::channel(());
+    sender
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,9 @@ pub mod limited;
 /// Private type alias for notify_full and notify_empty
 type Notifier = watch::Sender<()>;
 
+/// Public type alias for subscribe_full and subscribe_empty
+pub type Receiver = watch::Receiver<()>;
+
 /// Initialize the notify_full sender
 fn new_notifier() -> Notifier {
     let (sender, _) = watch::channel(());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,39 +29,41 @@
 //! | `resizable` | Enable resizable queue implementation | `deadqueue/unlimited` | yes |
 //! | `limited` | Enable limited queue implementation | – | yes |
 //!
-//! ## Example
-//!
-//! ```rust
-//! use std::sync::Arc;
-//! use tokio::time::{sleep, Duration};
-//!
-//! const TASK_COUNT: usize = 1000;
-//! const WORKER_COUNT: usize = 10;
-//!
-//! type TaskQueue = deadqueue::limited::Queue<usize>;
-//!
-//! #[tokio::main]
-//! async fn main() {
-//!     let queue = Arc::new(TaskQueue::new(TASK_COUNT));
-//!     for i in 0..TASK_COUNT {
-//!         queue.try_push(i).unwrap();
-//!     }
-//!     for worker in 0..WORKER_COUNT {
-//!         let queue = queue.clone();
-//!         tokio::spawn(async move {
-//!             loop {
-//!                 let task = queue.pop().await;
-//!                 println!("worker[{}] processing task[{}] ...", worker, task);
-//!             }
-//!         });
-//!     }
-//!     while queue.len() > 0 {
-//!         println!("Waiting for workers to finish...");
-//!         sleep(Duration::from_millis(100)).await;
-//!     }
-//!     println!("All tasks done. :-)");
-//! }
-//! ```
+#![cfg_attr(feature = "limited", doc = r##"
+## Example
+
+```rust
+use std::sync::Arc;
+use tokio::time::{sleep, Duration};
+
+const TASK_COUNT: usize = 1000;
+const WORKER_COUNT: usize = 10;
+
+type TaskQueue = deadqueue::limited::Queue<usize>;
+
+#[tokio::main]
+async fn main() {
+    let queue = Arc::new(TaskQueue::new(TASK_COUNT));
+    for i in 0..TASK_COUNT {
+        queue.try_push(i).unwrap();
+    }
+    for worker in 0..WORKER_COUNT {
+        let queue = queue.clone();
+        tokio::spawn(async move {
+            loop {
+                let task = queue.pop().await;
+                println!("worker[{}] processing task[{}] ...", worker, task);
+            }
+        });
+    }
+    while queue.len() > 0 {
+        println!("Waiting for workers to finish...");
+        sleep(Duration::from_millis(100)).await;
+    }
+    println!("All tasks done. :-)");
+}
+```
+"##)]
 //!
 //! ## Reasons for yet another queue
 //!

--- a/src/limited.rs
+++ b/src/limited.rs
@@ -7,7 +7,7 @@ use crossbeam_queue::ArrayQueue;
 use tokio::sync::Semaphore;
 
 use crate::atomic::Available;
-use crate::Notifier;
+use crate::{Notifier, Receiver};
 
 /// Queue that is limited in size and does not support resizing.
 ///
@@ -136,7 +136,12 @@ impl<T> Queue<T> {
         if self.len() == self.capacity() {
             return;
         }
-        self.notifier_full.subscribe().changed().await.unwrap();
+        self.subscribe_full().changed().await.unwrap();
+    }
+    /// Get a `Receiver` object that can repeatedly be awaited for
+    /// queue-full notifications.
+    pub fn subscribe_full(&self) -> Receiver {
+        self.notifier_full.subscribe()
     }
     /// Check if the queue is empty and notify any waiters
     fn notify_empty(&self) {
@@ -147,7 +152,12 @@ impl<T> Queue<T> {
         if self.is_empty() {
             return;
         }
-        self.notifier_empty.subscribe().changed().await.unwrap();
+        self.subscribe_empty().changed().await.unwrap();
+    }
+    /// Get a `Receiver` object that can repeatedly be awaited for
+    /// queue-empty notifications.
+    pub fn subscribe_empty(&self) -> Receiver {
+        self.notifier_empty.subscribe()
     }
 }
 

--- a/src/limited.rs
+++ b/src/limited.rs
@@ -87,6 +87,7 @@ impl<T> Queue<T> {
     pub fn try_push(&self, item: T) -> Result<(), T> {
         match self.push_semaphore.try_acquire() {
             Ok(permit) => {
+                self.available.add();
                 self.queue.push(item).ok().unwrap();
                 permit.forget();
                 self.pop_semaphore.add_permits(1);

--- a/src/limited.rs
+++ b/src/limited.rs
@@ -109,6 +109,16 @@ impl<T> Queue<T> {
     pub fn available(&self) -> isize {
         self.available.get()
     }
+    /// Await until the queue is full.
+    pub async fn full(&self) {
+        let capacity = self.capacity().try_into().unwrap();
+        let _ = self.pop_semaphore.acquire_many(capacity).await.unwrap();
+    }
+    /// Await until the queue is empty.
+    pub async fn empty(&self) {
+        let capacity = self.capacity().try_into().unwrap();
+        let _ = self.push_semaphore.acquire_many(capacity).await.unwrap();
+    }
 }
 
 impl<T, I> From<I> for Queue<T>

--- a/src/resizable.rs
+++ b/src/resizable.rs
@@ -186,20 +186,15 @@ impl<T> Queue<T> {
                         // Important: Call `self.queue.pop` and not
                         // `self.pop` as the former would add permits to
                         // the `push_semaphore` which we don't want to
-                        // happen since the queue is being shrinked.
+                        // happen since the queue is being shrunk.
                         _ = self.queue.pop() => {}
                     };
                     self.capacity.fetch_sub(1, Ordering::Relaxed);
                 }
-                // Currently this is a no-op because this resize() function
-                // borrows mutably, so there can be no callers awaiting
-                // `self.full()`, because they would hold an immutable reference.
-                //
-                // The code in self.resize() doesn't require mutability, though.
-                // If the API changes in a future version, this call should remain
-                // here so any callers awaiting `self.full()` will be notified
-                // if the queue is resized smaller such that it becomes full.
-                self.notify_full();
+
+                if self.is_full() {
+                    self.notify_full();
+                }
             }
             _ => {}
         }

--- a/src/resizable.rs
+++ b/src/resizable.rs
@@ -9,7 +9,7 @@ use tokio::sync::{Mutex, Semaphore};
 
 use crate::atomic::Available;
 use crate::unlimited::Queue as UnlimitedQueue;
-use crate::Notifier;
+use crate::{Notifier, Receiver};
 
 /// Queue that is limited in size and supports resizing.
 ///
@@ -130,7 +130,12 @@ impl<T> Queue<T> {
         if self.len() == self.capacity() {
             return;
         }
-        self.notifier_full.subscribe().changed().await.unwrap();
+        self.subscribe_full().changed().await.unwrap();
+    }
+    /// Get a `Receiver` object that can repeatedly be awaited for
+    /// queue-full notifications.
+    pub fn subscribe_full(&self) -> Receiver {
+        self.notifier_full.subscribe()
     }
     /// Check if the queue is empty and notify any waiters
     fn notify_empty(&self) {
@@ -141,7 +146,12 @@ impl<T> Queue<T> {
         if self.is_empty() {
             return;
         }
-        self.notifier_empty.subscribe().changed().await.unwrap();
+        self.subscribe_empty().changed().await.unwrap();
+    }
+    /// Get a `Receiver` object that can repeatedly be awaited for
+    /// queue-empty notifications.
+    pub fn subscribe_empty(&self) -> Receiver {
+        self.notifier_empty.subscribe()
     }
     /// Resize queue. This increases or decreases the queue
     /// capacity accordingly.

--- a/src/unlimited.rs
+++ b/src/unlimited.rs
@@ -33,11 +33,11 @@ impl<T> Queue<T> {
     /// Get an item from the queue. If the queue is currently empty
     /// this method blocks until an item is available.
     pub async fn pop(&self) -> T {
-        let (txn, previous) = self.available.sub();
+        let (txn, new_len) = self.available.sub();
         let permit = self.semaphore.acquire().await.unwrap();
         let item = self.queue.pop().unwrap();
         txn.commit();
-        if previous <= 1 {
+        if new_len <= 0 {
             self.notify_empty();
         }
         permit.forget();
@@ -46,11 +46,11 @@ impl<T> Queue<T> {
     /// Try to get an item from the queue. If the queue is currently
     /// empty return None instead.
     pub fn try_pop(&self) -> Option<T> {
-        let (txn, previous) = self.available.sub();
+        let (txn, new_len) = self.available.sub();
         let permit = self.semaphore.try_acquire().ok()?;
         let item = self.queue.pop().unwrap();
         txn.commit();
-        if previous <= 1 {
+        if new_len <= 0 {
             self.notify_empty();
         }
         permit.forget();

--- a/src/unlimited.rs
+++ b/src/unlimited.rs
@@ -8,7 +8,7 @@ use crossbeam_queue::SegQueue;
 use tokio::sync::Semaphore;
 
 use crate::atomic::Available;
-use crate::Notifier;
+use crate::{Notifier, Receiver};
 
 /// Queue that is unlimited in size.
 ///
@@ -80,12 +80,17 @@ impl<T> Queue<T> {
     fn notify_empty(&self) {
         self.notifier_empty.send_replace(());
     }
-    /// Await until the queue is empty
+    /// Await until the queue is empty.
     pub async fn wait_empty(&self) {
         if self.is_empty() {
             return;
         }
-        self.notifier_empty.subscribe().changed().await.unwrap()
+        self.subscribe_empty().changed().await.unwrap();
+    }
+    /// Get a `Receiver` object that can repeatedly be awaited for
+    /// queue-empty notifications.
+    pub fn subscribe_empty(&self) -> Receiver {
+        self.notifier_empty.subscribe()
     }
 }
 

--- a/src/unlimited.rs
+++ b/src/unlimited.rs
@@ -35,10 +35,8 @@ impl<T> Queue<T> {
     pub async fn pop(&self) -> T {
         let txn = self.available.sub();
         let permit = self.semaphore.acquire().await.unwrap();
-        txn.commit();
-        //txn.commit();
-        // FIXME must be used
         let item = self.queue.pop().unwrap();
+        txn.commit();
         permit.forget();
         self.notify_if_empty();
         item

--- a/tests/limited.rs
+++ b/tests/limited.rs
@@ -42,6 +42,37 @@ mod tests {
         assert_eq!(queue.len(), 0);
     }
 
+    #[tokio::test]
+    async fn test_full() {
+        let queue: Arc<Queue<usize>> = Arc::new(Queue::new(100));
+        let future_queue = queue.clone();
+        let future = tokio::spawn(async move {
+            future_queue.full().await;
+        });
+        for i in 0..100 {
+            queue.push(i).await;
+        }
+        future.await.unwrap();
+        assert_eq!(queue.len(), 100);
+    }
+
+    #[tokio::test]
+    async fn test_empty() {
+        let queue: Arc<Queue<usize>> = Arc::new(Queue::new(100));
+        for i in 0..100 {
+            queue.push(i).await;
+        }
+        let future_queue = queue.clone();
+        let future = tokio::spawn(async move {
+            future_queue.empty().await;
+        });
+        for _ in 0..100 {
+            queue.pop().await;
+        }
+        future.await.unwrap();
+        assert_eq!(queue.len(), 0);
+    }
+
     #[test]
     fn test_debug() {
         struct NoDebug {}

--- a/tests/limited.rs
+++ b/tests/limited.rs
@@ -51,7 +51,7 @@ mod tests {
         let future = tokio::spawn(async move {
             future_barrier.wait().await;
             assert_ne!(future_queue.capacity(), future_queue.len());
-            future_queue.full().await;
+            future_queue.wait_full().await;
         });
         barrier.wait().await;
         for i in 0..100 {
@@ -73,10 +73,54 @@ mod tests {
         let future = tokio::spawn(async move {
             future_barrier.wait().await;
             assert!(!future_queue.is_empty());
-            future_queue.empty().await;
+            future_queue.wait_empty().await;
         });
         barrier.wait().await;
         for _ in 0..100 {
+            queue.pop().await;
+        }
+        future.await.unwrap();
+        assert_eq!(queue.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_full_deadlock() {
+        let queue: Arc<Queue<()>> = Arc::new(Queue::new(2));
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+        let future_queue = queue.clone();
+        let future_barrier = barrier.clone();
+        let future = tokio::spawn(async move {
+            future_barrier.wait().await;
+            assert_ne!(future_queue.capacity(), future_queue.len());
+            future_queue.wait_full().await;
+        });
+        barrier.wait().await;
+        queue.push(()).await;
+        queue.pop().await;
+        for _ in 0..2 {
+            queue.push(()).await;
+        }
+        future.await.unwrap();
+        assert_eq!(queue.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_empty_deadlock() {
+        let queue: Arc<Queue<()>> = Arc::new(Queue::new(3));
+        for _ in 0..2 {
+            queue.push(()).await;
+        }
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+        let future_queue = queue.clone();
+        let future_barrier = barrier.clone();
+        let future = tokio::spawn(async move {
+            future_barrier.wait().await;
+            assert!(!future_queue.is_empty());
+            future_queue.wait_empty().await;
+        });
+        barrier.wait().await;
+        queue.push(()).await;
+        for _ in 0..3 {
             queue.pop().await;
         }
         future.await.unwrap();

--- a/tests/limited.rs
+++ b/tests/limited.rs
@@ -22,6 +22,18 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_available() {
+        let queue: Queue<usize> = Queue::new(2);
+        assert_eq!(queue.len(), 0);
+        assert!(queue.try_push(1).is_ok());
+        assert_eq!(queue.len(), 1);
+        assert_eq!(queue.available(), 1);
+        assert!(queue.try_pop().is_some());
+        assert_eq!(queue.len(), 0);
+        assert_eq!(queue.available(), 0);
+    }
+
+    #[tokio::test]
     async fn test_parallel() {
         let queue: Arc<Queue<usize>> = Arc::new(Queue::new(100));
         let mut futures = Vec::new();
@@ -40,6 +52,33 @@ mod tests {
             future.await.unwrap();
         }
         assert_eq!(queue.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_parallel_available() {
+        const N: usize = 2;
+        let queue: Arc<Queue<usize>> = Arc::new(Queue::new(N));
+        let barrier = Arc::new(tokio::sync::Barrier::new(N + 1));
+        let mut futures = Vec::new();
+        for _ in 0..N {
+            let queue = queue.clone();
+            let barrier = barrier.clone();
+            futures.push(tokio::spawn(async move {
+                barrier.wait().await;
+                queue.pop().await;
+            }));
+        }
+        barrier.wait().await;
+        assert_eq!(queue.len(), 0);
+        assert_eq!(queue.available(), -(N as isize));
+        for i in 0..N {
+            queue.push(i).await;
+        }
+        for future in futures {
+            future.await.unwrap();
+        }
+        assert_eq!(queue.len(), 0);
+        assert_eq!(queue.available(), 0);
     }
 
     #[tokio::test]

--- a/tests/limited.rs
+++ b/tests/limited.rs
@@ -45,10 +45,15 @@ mod tests {
     #[tokio::test]
     async fn test_full() {
         let queue: Arc<Queue<usize>> = Arc::new(Queue::new(100));
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
         let future_queue = queue.clone();
+        let future_barrier = barrier.clone();
         let future = tokio::spawn(async move {
+            future_barrier.wait().await;
+            assert_ne!(future_queue.capacity(), future_queue.len());
             future_queue.full().await;
         });
+        barrier.wait().await;
         for i in 0..100 {
             queue.push(i).await;
         }
@@ -62,10 +67,15 @@ mod tests {
         for i in 0..100 {
             queue.push(i).await;
         }
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
         let future_queue = queue.clone();
+        let future_barrier = barrier.clone();
         let future = tokio::spawn(async move {
+            future_barrier.wait().await;
+            assert!(!future_queue.is_empty());
             future_queue.empty().await;
         });
+        barrier.wait().await;
         for _ in 0..100 {
             queue.pop().await;
         }

--- a/tests/resizable.rs
+++ b/tests/resizable.rs
@@ -47,6 +47,37 @@ mod tests {
         assert_eq!(queue.len(), 0);
     }
 
+    #[tokio::test]
+    async fn test_full() {
+        let queue: Arc<Queue<usize>> = Arc::new(Queue::new(100));
+        let future_queue = queue.clone();
+        let future = tokio::spawn(async move {
+            future_queue.full().await;
+        });
+        for i in 0..100 {
+            queue.push(i).await;
+        }
+        future.await.unwrap();
+        assert_eq!(queue.len(), 100);
+    }
+
+    #[tokio::test]
+    async fn test_empty() {
+        let queue: Arc<Queue<usize>> = Arc::new(Queue::new(100));
+        for i in 0..100 {
+            queue.push(i).await;
+        }
+        let future_queue = queue.clone();
+        let future = tokio::spawn(async move {
+            future_queue.empty().await;
+        });
+        for _ in 0..100 {
+            queue.pop().await;
+        }
+        future.await.unwrap();
+        assert_eq!(queue.len(), 0);
+    }
+
     #[test]
     fn test_debug() {
         struct NoDebug {}

--- a/tests/unlimited.rs
+++ b/tests/unlimited.rs
@@ -16,6 +16,18 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_available() {
+        let queue: Queue<usize> = Queue::new();
+        assert_eq!(queue.len(), 0);
+        queue.push(1);
+        assert_eq!(queue.len(), 1);
+        assert_eq!(queue.available(), 1);
+        assert!(queue.try_pop().is_some());
+        assert_eq!(queue.len(), 0);
+        assert_eq!(queue.available(), 0);
+    }
+
+    #[tokio::test]
     async fn test_pop() {
         let queue: Queue<usize> = Queue::from_iter(vec![1, 2, 3, 4, 5]);
         for i in 0..5 {
@@ -42,6 +54,33 @@ mod tests {
                     queue.pop().await;
                 }
             }));
+        }
+        for future in futures {
+            future.await.unwrap();
+        }
+        assert_eq!(queue.len(), 0);
+        assert_eq!(queue.available(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_parallel_available() {
+        const N: usize = 2;
+        let queue: Arc<Queue<usize>> = Arc::new(Queue::new());
+        let barrier = Arc::new(tokio::sync::Barrier::new(N + 1));
+        let mut futures = Vec::new();
+        for _ in 0..N {
+            let queue = queue.clone();
+            let barrier = barrier.clone();
+            futures.push(tokio::spawn(async move {
+                barrier.wait().await;
+                queue.pop().await;
+            }));
+        }
+        barrier.wait().await;
+        assert_eq!(queue.len(), 0);
+        assert_eq!(queue.available(), -(N as isize));
+        for i in 0..N {
+            queue.push(i);
         }
         for future in futures {
             future.await.unwrap();


### PR DESCRIPTION
Allow awaiting a full or empty queue.

- `Queue.empty()` is useful for chaining futures
  in a multi-threaded program when some subsequent
  action, like a verification step, needs to be
  taken once the queue is emptied.
- `Queue.full()` can help manage backpressure so that
  an autoscaling system can monitor when the queue fills
  before it starts increasing the number of workers.