### PR TITLE
Add is_full() to limited.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - unreleased
+
+### Added
+
+- Added `is_full` to limited and resizable queues
+
 ## [0.2.2] - 2022-05-01
 
 ### Added
 
-- Fix `resize` implementation of resiable queue
+- Fix `resize` implementation of resizable queue
 
 ## [0.2.1] - 2022-03-11
 

--- a/src/limited.rs
+++ b/src/limited.rs
@@ -87,17 +87,21 @@ impl<T> Queue<T> {
             Err(_) => Err(item),
         }
     }
-    /// Get capacity of the queue
+    /// Get capacity of the queue (maximum number of items queue can store)
     pub fn capacity(&self) -> usize {
         self.queue.capacity()
     }
-    /// Get current length of queue
+    /// Get current length of queue (number of items currently stored)
     pub fn len(&self) -> usize {
         self.queue.len()
     }
     /// Returns `true` if the queue is empty.
     pub fn is_empty(&self) -> bool {
         self.queue.is_empty()
+    }
+    /// Returns `true` if the queue is full.
+    pub fn is_full(&self) -> bool {
+        self.queue.is_full()
     }
     /// The number of available items in the queue. If there are no
     /// items in the queue this number can become negative and stores the

--- a/src/resizable.rs
+++ b/src/resizable.rs
@@ -69,11 +69,11 @@ impl<T> Queue<T> {
             Err(_) => Err(item),
         }
     }
-    /// Get capacity of the queue
+    /// Get capacity of the queue (maximum number of items queue can store).
     pub fn capacity(&self) -> usize {
         self.capacity.load(Ordering::Relaxed)
     }
-    /// Get current length of queue
+    /// Get current length of queue (number of items currently stored).
     pub fn len(&self) -> usize {
         self.queue.len()
     }

--- a/src/resizable.rs
+++ b/src/resizable.rs
@@ -81,6 +81,14 @@ impl<T> Queue<T> {
     pub fn is_empty(&self) -> bool {
         self.queue.is_empty()
     }
+    /// Returns `true` if the queue is full.
+    /// **Note:** this can give an incorrect result if a simultaneous push/pop
+    /// and resize ocurr while this function is executing. try_push() is the
+    /// reccomended and safer mechanism in most circumstances. This method
+    /// is provided as a convenience API.
+    pub fn is_full(&self) -> bool {
+        self.len() >= self.capacity()
+    }
     /// The number of available items in the queue. If there are no
     /// items in the queue this number can become negative and stores the
     /// number of futures waiting for an item.

--- a/src/unlimited.rs
+++ b/src/unlimited.rs
@@ -55,7 +55,7 @@ impl<T> Queue<T> {
         self.semaphore.add_permits(1);
         self.available.add();
     }
-    /// Get current length of queue
+    /// Get current length of queue (number of items currently stored).
     pub fn len(&self) -> usize {
         self.queue.len()
     }

--- a/tests/resizable.rs
+++ b/tests/resizable.rs
@@ -74,4 +74,19 @@ mod tests {
         assert_eq!(queue.len(), 0);
         assert_eq!(queue.try_push(42), Err(42));
     }
+
+    #[tokio::test]
+    async fn test_is_full_basic() {
+        let queue: Queue<usize> = Queue::new(2);
+        assert!(!queue.is_full(), "Should be empty at construction");
+        queue.push(1).await;
+        assert!(
+            !queue.is_full(),
+            "Should not be full a one less than capacity"
+        );
+        queue.push(2).await;
+        assert!(queue.is_full(), "Should now be full");
+        let _ = queue.pop().await;
+        assert!(!queue.is_full(), "Should no longer be full after pop");
+    }
 }


### PR DESCRIPTION
is_full() is a useful function and an existing method of the underlying crossbeam queue type. I believe exposing it has limited / no downsides and slightly improves usability.

Additionally expanded some doc strings around len() vs capacity() where I had initial (minor) confusion.